### PR TITLE
fix: use Bash

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Regex to validate the type pattern
 REGEX="^((Merge[ a-z-]* branch.*)|(Revert*)|((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?!?: .*))"


### PR DESCRIPTION
You're using bashisms in the `commit-msg` hook script, but with the `#!/bin/sh` shebang, Bash is executed in [POSIX-compliant mode](https://www.gnu.org/software/bash/manual/html_node/Bash-POSIX-Mode.html). To properly interpret the regex, we need to specify the `#!/bin/bash` shebang.

An alternative would be to use only POSIX-compliant shell syntax.